### PR TITLE
Improve annotation providers and add method inspectors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-group = "com.atlas"
+group = "com.qibergames"
 version = System.getenv("VERSION") ?: "1.0-SNAPSHOT"
 
 repositories {

--- a/src/main/java/com/qibergames/divine/Container.java
+++ b/src/main/java/com/qibergames/divine/Container.java
@@ -4,6 +4,7 @@ import com.qibergames.divine.descriptor.generic.Service;
 import com.qibergames.divine.descriptor.generic.ServiceLike;
 import com.qibergames.divine.exception.InvalidServiceException;
 import com.qibergames.divine.exception.ServiceInitializationException;
+import com.qibergames.divine.method.MethodInspector;
 import com.qibergames.divine.provider.AnnotationProvider;
 import com.qibergames.divine.provider.Ref;
 import com.qibergames.divine.tree.cache.ContainerHook;
@@ -129,8 +130,8 @@ public class Container {
      *
      * @throws InvalidServiceException if the annotation does not have a RUNTIME retention
      */
-    public void addProvider(
-        @NotNull Class<? extends Annotation> annotation, @NotNull AnnotationProvider<?, ?> provider
+    public <TAnnotation extends Annotation> void addProvider(
+        @NotNull Class<TAnnotation> annotation, @NotNull AnnotationProvider<?, TAnnotation> provider
     ) {
         CallContext context = getContextContainer();
         context.getContainer().addProvider(annotation, provider);
@@ -144,6 +145,31 @@ public class Container {
     public void removeProvider(@NotNull Class<? extends Annotation> annotation) {
         CallContext context = getContextContainer();
         context.getContainer().removeProvider(annotation);
+    }
+
+    /**
+     * Register a new method inspector for the specified annotation.
+     * <p>
+     * The inspector will be notified of each method upon service instantiation, that specify this annotation.
+     *
+     * @param annotation the annotation that marks methods to be inspected
+     * @param inspector the method inspection callback
+     */
+    public <TAnnotation extends Annotation> void addInspector(
+        @NotNull Class<TAnnotation> annotation, @NotNull MethodInspector<TAnnotation> inspector
+    ) {
+        CallContext context = getContextContainer();
+        context.getContainer().addInspector(annotation, inspector);
+    }
+
+    /**
+     * Remove a method inspector for the specified annotation.
+     *
+     * @param annotation the annotation that marks methods to be inspected
+     */
+    public void removeInspector(@NotNull Class<? extends Annotation> annotation) {
+        CallContext context = getContextContainer();
+        context.getContainer().removeInspector(annotation);
     }
 
     /**

--- a/src/main/java/com/qibergames/divine/descriptor/generic/InjectionType.java
+++ b/src/main/java/com/qibergames/divine/descriptor/generic/InjectionType.java
@@ -1,4 +1,4 @@
-package com.qibergames.divine.impl;
+package com.qibergames.divine.descriptor.generic;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @RequiredArgsConstructor
 @Getter
-public enum InjectionTarget {
+public enum InjectionType {
     /**
      * `CLASS_FIELD` indicates, that the dependency should be injected into a class field.
      */

--- a/src/main/java/com/qibergames/divine/impl/DefaultContainerImpl.java
+++ b/src/main/java/com/qibergames/divine/impl/DefaultContainerImpl.java
@@ -932,7 +932,11 @@ public class DefaultContainerImpl implements ContainerRegistry {
 
                 // call the inspector with the current method
                 ServiceMethod info = new ServiceMethodImpl(type, instance, method);
-                ((MethodInspector) inspector).inspect(info, annotationInstance, this);
+                try {
+                    ((MethodInspector) inspector).inspect(info, annotationInstance, this);
+                } catch (Exception e) {
+                    throw new ServiceInitializationException("Error while inspecting method " + method, e);
+                }
             });
         }
     }

--- a/src/main/java/com/qibergames/divine/impl/ServiceMethodImpl.java
+++ b/src/main/java/com/qibergames/divine/impl/ServiceMethodImpl.java
@@ -1,0 +1,52 @@
+package com.qibergames.divine.impl;
+
+import com.qibergames.divine.exception.ServiceRuntimeException;
+import com.qibergames.divine.method.ServiceMethod;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * Represents a service method information holder.
+ */
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+@Getter
+public class ServiceMethodImpl implements ServiceMethod {
+    /**
+     * The service that declares the method.
+     */
+    private final Class<?> target;
+
+    /**
+     * The instance of the service.
+     */
+    private final Object instance;
+
+    /**
+     * The handle of the service method.
+     */
+    private final Method handle;
+
+    /**
+     * Invoke the inspected method with the specified arguments.
+     * <p>
+     * The service instance will be the target of the invocation.
+     *
+     * @param args the arguments to invoke the method with
+     * @return the return value of the invocation
+     */
+    @Override
+    public @Nullable Object invoke(@NotNull Object @Nullable ... args) {
+        try {
+            handle.setAccessible(true);
+            return handle.invoke(instance, args);
+        } catch (Throwable t) {
+            throw new ServiceRuntimeException("Unable to invoke service method `" + handle.getName() + "`", t);
+        }
+    }
+}

--- a/src/main/java/com/qibergames/divine/method/MethodInspector.java
+++ b/src/main/java/com/qibergames/divine/method/MethodInspector.java
@@ -1,0 +1,25 @@
+package com.qibergames.divine.method;
+
+import com.qibergames.divine.tree.ContainerInstance;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Represents a functional interface that provides access to a method of a service instance.
+ * <p>
+ * The {@link #inspect(ServiceMethod, Annotation, ContainerInstance)} method is called for each class method, that has
+ * a special annotation registered in the container.
+ */
+public interface MethodInspector<TAnnotation extends Annotation> {
+    /**
+     * Inspect a class method of a service class, that annotated a method with a special annotation.
+     *
+     * @param method the method of the service
+     * @param annotation the annotation instance
+     * @param container the container that requested a dependency for the service
+     */
+    void inspect(
+        @NotNull ServiceMethod method, @NotNull TAnnotation annotation, @NotNull ContainerInstance container
+    );
+}

--- a/src/main/java/com/qibergames/divine/method/ServiceMethod.java
+++ b/src/main/java/com/qibergames/divine/method/ServiceMethod.java
@@ -1,0 +1,42 @@
+package com.qibergames.divine.method;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * Represents a service method information holder.
+ */
+public interface ServiceMethod {
+    /**
+     * The service that declares the method.
+     *
+     * @return the class type of the service
+     */
+    @NotNull Class<?> target();
+
+    /**
+     * The instance of the service.
+     *
+     * @return the instance of the class type
+     */
+    @NotNull Object instance();
+
+    /**
+     * The handle of the service method.
+     *
+     * @return the reflection access to the service method
+     */
+    @NotNull Method handle();
+
+    /**
+     * Invoke the inspected method with the specified arguments.
+     * <p>
+     * The service instance will be the target of the invocation.
+     *
+     * @param args the arguments to invoke the method with
+     * @return the return value of the invocation
+     */
+    @Nullable Object invoke(@NotNull Object @Nullable ... args);
+}

--- a/src/main/java/com/qibergames/divine/provider/AnnotationProvider.java
+++ b/src/main/java/com/qibergames/divine/provider/AnnotationProvider.java
@@ -9,8 +9,9 @@ import java.lang.annotation.Annotation;
 /**
  * Represents a functional interface that provides an implementation for the specified interface.
  * <p>
- * The {@link #provide(Class, Annotation, ContainerInstance)} method is called, to resolve the implementation of a service,
- * whenever its corresponding custom annotation is present on a field or constructor parameter.
+ * The {@link #provide(Class, Annotation, ContainerInstance, InjectionHandle)} method is called, to resolve the
+ * implementation of a service, whenever its corresponding custom annotation is present on a field or constructor
+ * parameter.
  *
  * @param <TImplementation> the type of the service that this class provides an implementation for
  * @param <TAnnotation> the type of the annotation that is present on the field or constructor parameter
@@ -23,12 +24,12 @@ public interface AnnotationProvider<@ServiceLike TImplementation, TAnnotation ex
      * @param target the target interface that the implementation is being provided for
      * @param annotation the annotation that is present on the field or constructor parameter
      * @param container the container instance that the implementation is being provided from
+     * @param handle the type of the injection and information of the requesting service
      *
      * @return the implementation of the specified interface
      */
     @NotNull TImplementation provide(
-        @NotNull Class<?> target,
-        @NotNull TAnnotation annotation,
-        @NotNull ContainerInstance container
+        @NotNull Class<?> target, @NotNull TAnnotation annotation, @NotNull ContainerInstance container,
+        @NotNull InjectionHandle handle
     );
 }

--- a/src/main/java/com/qibergames/divine/provider/AnnotationProvider.java
+++ b/src/main/java/com/qibergames/divine/provider/AnnotationProvider.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.annotation.Annotation;
 
 /**
- * Represents a functional interface that provides an implementation for the specified interface.
+ * Represents a functional interface that provides an implementation for a service interface.
  * <p>
  * The {@link #provide(Class, Annotation, ContainerInstance, InjectionHandle)} method is called, to resolve the
  * implementation of a service, whenever its corresponding custom annotation is present on a field or constructor

--- a/src/main/java/com/qibergames/divine/provider/ConstructorInjectionHandle.java
+++ b/src/main/java/com/qibergames/divine/provider/ConstructorInjectionHandle.java
@@ -1,0 +1,25 @@
+package com.qibergames.divine.provider;
+
+import com.qibergames.divine.descriptor.generic.InjectionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a constructor injection information.
+ */
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+@Getter
+public class ConstructorInjectionHandle implements InjectionHandle {
+    /**
+     * The kind of the injection.
+     */
+    private final InjectionType type = InjectionType.CONSTRUCTOR_PARAMETER;
+
+    /**
+     * The service class that requested the dependency.
+     */
+    private final @NotNull Class<?> target;
+}

--- a/src/main/java/com/qibergames/divine/provider/FieldInjectionHandle.java
+++ b/src/main/java/com/qibergames/divine/provider/FieldInjectionHandle.java
@@ -1,0 +1,37 @@
+package com.qibergames.divine.provider;
+
+import com.qibergames.divine.descriptor.generic.InjectionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+/**
+ * Represents a field injection information.
+ */
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+@Getter
+public class FieldInjectionHandle implements InjectionHandle {
+    /**
+     * The kind of the injection.
+     */
+    public final InjectionType type = InjectionType.CLASS_FIELD;
+
+    /**
+     * The service class that requested the dependency.
+     */
+    private final @NotNull Class<?> target;
+
+    /**
+     * The instance of the requesting class.
+     */
+    private final @NotNull Object instance;
+
+    /**
+     * The field that the container want to inject into.
+     */
+    private final @NotNull Field field;
+}

--- a/src/main/java/com/qibergames/divine/provider/InjectionHandle.java
+++ b/src/main/java/com/qibergames/divine/provider/InjectionHandle.java
@@ -1,0 +1,23 @@
+package com.qibergames.divine.provider;
+
+import com.qibergames.divine.descriptor.generic.InjectionType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a field or constructor injection information.
+ */
+public interface InjectionHandle {
+    /**
+     * The service class that requested the dependency.
+     *
+     * @return the dependency owner class type
+     */
+    @NotNull Class<?> target();
+
+    /**
+     * The kind of the injection.
+     *
+     * @return either {@link InjectionType#CLASS_FIELD} or {@link InjectionType#CONSTRUCTOR_PARAMETER}
+     */
+    @NotNull InjectionType type();
+}

--- a/src/main/java/com/qibergames/divine/tree/ContainerInstance.java
+++ b/src/main/java/com/qibergames/divine/tree/ContainerInstance.java
@@ -5,6 +5,7 @@ import com.qibergames.divine.descriptor.generic.Service;
 import com.qibergames.divine.descriptor.generic.ServiceLike;
 import com.qibergames.divine.exception.InvalidServiceException;
 import com.qibergames.divine.exception.ServiceInitializationException;
+import com.qibergames.divine.method.MethodInspector;
 import com.qibergames.divine.provider.AnnotationProvider;
 import com.qibergames.divine.provider.Ref;
 import com.qibergames.divine.tree.cache.ContainerHook;
@@ -47,7 +48,9 @@ public interface ContainerInstance {
      *
      * @throws InvalidServiceException if the annotation does not have a RUNTIME retention
      */
-    void addProvider(@NotNull Class<? extends Annotation> annotation, @NotNull AnnotationProvider<?, ?> provider);
+    <TAnnotation extends Annotation> void addProvider(
+        @NotNull Class<TAnnotation> annotation, @NotNull AnnotationProvider<?, TAnnotation> provider
+    );
 
     /**
      * Remove a custom annotation from the container instance.
@@ -55,6 +58,25 @@ public interface ContainerInstance {
      * @param annotation the custom annotation that will be removed
      */
     void removeProvider(@NotNull Class<? extends Annotation> annotation);
+
+    /**
+     * Register a new method inspector for the specified annotation.
+     * <p>
+     * The inspector will be notified of each method upon service instantiation, that specify this annotation.
+     *
+     * @param annotation the annotation that marks methods to be inspected
+     * @param inspector the method inspection callback
+     */
+    <TAnnotation extends Annotation> void addInspector(
+        @NotNull Class<TAnnotation> annotation, @NotNull MethodInspector<TAnnotation> inspector
+    );
+
+    /**
+     * Remove a method inspector for the specified annotation.
+     *
+     * @param annotation the annotation that marks methods to be inspected
+     */
+    void removeInspector(@NotNull Class<? extends Annotation> annotation);
 
     /**
      * Register services in the container, that specify {@link Service#multiple()} = {@code true} in their descriptor.

--- a/src/test/java/com/qibergames/divine/ContainerTest.java
+++ b/src/test/java/com/qibergames/divine/ContainerTest.java
@@ -3,6 +3,8 @@ package com.qibergames.divine;
 import com.qibergames.divine.exception.CircularDependencyException;
 import com.qibergames.divine.exception.InvalidServiceAccessException;
 import com.qibergames.divine.exception.InvalidServiceException;
+import com.qibergames.divine.method.MethodInspector;
+import com.qibergames.divine.method.ServiceMethod;
 import com.qibergames.divine.provider.AnnotationProvider;
 import com.qibergames.divine.provider.InjectionHandle;
 import com.qibergames.divine.provider.Ref;
@@ -571,5 +573,28 @@ class ContainerTest {
         container.removeHook("MY_HOOK");
         service = container.get(MyService.class);
         assertEquals(123, service.getValue());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface InspectorTarget {}
+
+    @Service
+    static class InspectedService {
+        public int value = 100;
+
+        @InspectorTarget
+        public void foo(int newValue) {
+            value = newValue;
+        }
+    }
+
+    @Test
+    public void test_method_inspector() {
+        Container.addInspector(
+            InspectorTarget.class,
+            (method, annotation, container) -> method.invoke(200)
+        );
+        InspectedService service = Container.get(InspectedService.class);
+        assertEquals(200, service.value);
     }
 }

--- a/src/test/java/com/qibergames/divine/ContainerTest.java
+++ b/src/test/java/com/qibergames/divine/ContainerTest.java
@@ -1,10 +1,10 @@
 package com.qibergames.divine;
 
-import com.qibergames.divine.Container;
 import com.qibergames.divine.exception.CircularDependencyException;
 import com.qibergames.divine.exception.InvalidServiceAccessException;
 import com.qibergames.divine.exception.InvalidServiceException;
 import com.qibergames.divine.provider.AnnotationProvider;
+import com.qibergames.divine.provider.InjectionHandle;
 import com.qibergames.divine.provider.Ref;
 import com.qibergames.divine.runtime.lifecycle.AfterInitialized;
 import com.qibergames.divine.tree.ContainerInstance;
@@ -312,7 +312,8 @@ class ContainerTest {
     static class MyAnnotationProvider implements AnnotationProvider<MyCustomServiceImpl, MyCustomAnnotation> {
         @Override
         public @NotNull MyCustomServiceImpl provide(
-            @NotNull Class<?> target, @NotNull MyCustomAnnotation annotation, @NotNull ContainerInstance container
+            @NotNull Class<?> target, @NotNull MyCustomAnnotation annotation, @NotNull ContainerInstance container,
+            @NotNull InjectionHandle handle
         ) {
             return new MyCustomServiceImpl(annotation.val());
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering method inspectors to inspect and interact with service methods annotated with specific annotations during service instantiation.
  - Introduced interfaces and classes representing injection metadata for constructor parameters and class fields.
  - Enhanced annotation providers to receive injection context information.
- **Bug Fixes**
  - Improved type safety for annotation providers and inspectors through generic type parameters.
- **Tests**
  - Added tests verifying method inspector functionality and invocation of annotated service methods.
- **Documentation**
  - Updated API documentation to reflect new parameters and clarify injection context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->